### PR TITLE
Use latest test schema to fix build issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -153,9 +153,9 @@
       }
     },
     "@dvsa/mes-test-schema": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.2.3.tgz",
-      "integrity": "sha512-DQnQKKOZTo9swch9zvN0DQkOJlluMgjRXFLuRF6qJitl6ArUVlOIERQxrzY4s56mDUkXFAocovnO/HCwHw+lMA==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.2.5.tgz",
+      "integrity": "sha512-e1ZTjE6qkJJm1h71gTxG1XRulyQTWSOyWPxzcEb+tfrc+1VeYnM/Afpd43FKAbAHD2fy42LoPudcozaim/afMg==",
       "dev": true
     },
     "@fimbul/bifrost": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {
-    "@dvsa/mes-test-schema": "3.2.3",
+    "@dvsa/mes-test-schema": "3.2.5",
     "@types/aws-lambda": "^8.10.13",
     "@types/aws-sdk": "^2.7.0",
     "@types/jasmine": "^2.8.9",


### PR DESCRIPTION
Build failed due to case insensitivity issue in a dvsa npm package it referenced.
The npm package has been fixed, so now updating to use this version, this should fix the build.
