### PR TITLE
Mes 4182 cherry pick fix deprecated use of buffer

### DIFF
--- a/src/functions/tarsUpload/framework/adapter/fetch/HTTPBatchFetcher.ts
+++ b/src/functions/tarsUpload/framework/adapter/fetch/HTTPBatchFetcher.ts
@@ -34,7 +34,7 @@ export class HTTPBatchFetcher implements IBatchFetcher {
           let test: StandardCarTestCATBSchema;
 
           try {
-            uncompressedResult = zlib.gunzipSync(new Buffer(element, 'base64')).toString();
+            uncompressedResult = zlib.gunzipSync(Buffer.from(element, 'base64')).toString();
           } catch (e) {
             reject(new TestResultError('failed decompressing test result'));
           }

--- a/tslint.json
+++ b/tslint.json
@@ -4,7 +4,8 @@
       "no-unused-variable": false,
       "quotemark": [true, "single"],
       "indent": [true, "spaces", 2],
-      "max-line-length": [true, 120]
+      "max-line-length": [true, 120],
+      "deprecation": true
     },
     "extends": "tslint-config-airbnb"
 }


### PR DESCRIPTION
# Description and relevant Jira numbers
MES-4182 fix deprecated use of buffer, cherry pick of #39.
## Pull Request checklist

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA