### PR TITLE
MES-2871 - Submit Mod1 test result to TARS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -159,9 +159,9 @@
       }
     },
     "@dvsa/mes-test-schema": {
-      "version": "3.19.1",
-      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.19.1.tgz",
-      "integrity": "sha512-b+FNZIPO8ObEXTBxhgeQ8+Nhkjiaca/63Yw/Ar6+KFsco8OiljorSW3cCbElBYaNJBSWu6/aiB5bzrNMcItIZQ==",
+      "version": "3.20.1",
+      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.20.1.tgz",
+      "integrity": "sha512-X6o5YREhWFd2xvxPyhpFLw/XdP+JyGkTwqHkhymecWzaZvUViFr/MnsCPRGT25SL3jLNBuiwAiC1/qmf6dJZgQ==",
       "dev": true
     },
     "@fimbul/bifrost": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -159,9 +159,9 @@
       }
     },
     "@dvsa/mes-test-schema": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.19.0.tgz",
-      "integrity": "sha512-+A6EGXNvJ49D1vSZPGiGe2TEEPQan4P3hICCHaokQ55J9h+VFEuDPKZ+dbh84EgekhrG9o1FHiodEe7FrTlU8A==",
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.19.1.tgz",
+      "integrity": "sha512-b+FNZIPO8ObEXTBxhgeQ8+Nhkjiaca/63Yw/Ar6+KFsco8OiljorSW3cCbElBYaNJBSWu6/aiB5bzrNMcItIZQ==",
       "dev": true
     },
     "@fimbul/bifrost": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {
-    "@dvsa/mes-test-schema": "^3.20.1",
+    "@dvsa/mes-test-schema": "3.20.1",
     "@types/aws-lambda": "^8.10.13",
     "@types/aws-sdk": "^2.7.0",
     "@types/jasmine": "^2.8.9",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {
-    "@dvsa/mes-test-schema": "3.19.0",
+    "@dvsa/mes-test-schema": "3.19.1",
     "@types/aws-lambda": "^8.10.13",
     "@types/aws-sdk": "^2.7.0",
     "@types/jasmine": "^2.8.9",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {
-    "@dvsa/mes-test-schema": "3.19.1",
+    "@dvsa/mes-test-schema": "^3.20.1",
     "@types/aws-lambda": "^8.10.13",
     "@types/aws-sdk": "^2.7.0",
     "@types/jasmine": "^2.8.9",

--- a/src/functions/tarsUpload/domain/upload/TARSPayloadConverter.ts
+++ b/src/functions/tarsUpload/domain/upload/TARSPayloadConverter.ts
@@ -87,8 +87,7 @@ export class TARSPayloadConverter implements ITARSPayloadConverter {
 
   private setLicenceSurrendertoFalseIfNotPresent(passCompletion: Partial<PassCompletion> | undefined): boolean {
     if (!passCompletion) return false;
-    const resolvedProvisionalLicenceProvided = get(passCompletion, 'provisionalLicenceProvided', false);
-    return resolvedProvisionalLicenceProvided;
+    return get(passCompletion, 'provisionalLicenceProvided', false);
   }
 
   private populatePassCertificateIfPresent(

--- a/src/functions/tarsUpload/domain/upload/TARSPayloadConverter.ts
+++ b/src/functions/tarsUpload/domain/upload/TARSPayloadConverter.ts
@@ -12,7 +12,7 @@ import { IDateFormatter } from '../util/IDateFormatter';
 import { determineDl25TestType } from '../util/TestTypeLookup';
 import { licenceToIssue } from '@dvsa/mes-microservice-common/application/utils/licence-type';
 import { get } from 'lodash';
-import { PassCompletion } from '@dvsa/mes-test-schema/categories/common';
+import { PassCompletion, CategoryCode } from '@dvsa/mes-test-schema/categories/common';
 
 @injectable()
 export class TARSPayloadConverter implements ITARSPayloadConverter {
@@ -72,7 +72,7 @@ export class TARSPayloadConverter implements ITARSPayloadConverter {
       checkDigit,
       language: communicationPreferences.conductedLanguage === 'English' ? 'E' : 'W',
       licenceSurrender: this.setLicenceSurrendertoFalseIfNotPresent(passCompletion),
-      dl25Category: category,
+      dl25Category: this.dl25CategoryConversion(category),
       dl25TestType: testType,
       automaticTest: licenceToIssue(category, transmission, code78Present) === 'Automatic',
       extendedTest: testSlotAttributes.extendedTest,
@@ -88,6 +88,14 @@ export class TARSPayloadConverter implements ITARSPayloadConverter {
   private setLicenceSurrendertoFalseIfNotPresent(passCompletion: Partial<PassCompletion> | undefined): boolean {
     if (!passCompletion) return false;
     return get(passCompletion, 'provisionalLicenceProvided', false);
+  }
+
+  private dl25CategoryConversion(category: CategoryCode): string {
+    if (category.indexOf('EU') === 0) {
+      return category.substring(2);
+    }
+
+    return category;
   }
 
   private populatePassCertificateIfPresent(

--- a/src/functions/tarsUpload/domain/upload/TARSPayloadConverter.ts
+++ b/src/functions/tarsUpload/domain/upload/TARSPayloadConverter.ts
@@ -71,7 +71,7 @@ export class TARSPayloadConverter implements ITARSPayloadConverter {
       bookingSequence,
       checkDigit,
       language: communicationPreferences.conductedLanguage === 'English' ? 'E' : 'W',
-      licenceSurrender: passCompletion ? passCompletion.provisionalLicenceProvided : false,
+      licenceSurrender: this.setLicenceSurrendertoFalseIfNotPresent(passCompletion),
       dl25Category: category,
       dl25TestType: testType,
       automaticTest: licenceToIssue(category, transmission, code78Present) === 'Automatic',
@@ -85,9 +85,15 @@ export class TARSPayloadConverter implements ITARSPayloadConverter {
     return completedTestPayload;
   }
 
+  private setLicenceSurrendertoFalseIfNotPresent(passCompletion: Partial<PassCompletion> | undefined): boolean {
+    if (!passCompletion) return false;
+    const resolvedProvisionalLicenceProvided = get(passCompletion, 'provisionalLicenceProvided', false);
+    return resolvedProvisionalLicenceProvided;
+  }
+
   private populatePassCertificateIfPresent(
     completedTestPayload: CompletedTestPayload,
-    passCompletion: PassCompletion | undefined,
+    passCompletion: Partial<PassCompletion> | undefined,
   ): CompletedTestPayload {
     if (!passCompletion) {
       return completedTestPayload;

--- a/src/functions/tarsUpload/domain/upload/TARSPayloadConverter.ts
+++ b/src/functions/tarsUpload/domain/upload/TARSPayloadConverter.ts
@@ -10,9 +10,10 @@ import { CompletedTestPayloadCreationError } from './errors/CompletedTestPayload
 import { CompletedTestInvalidCategoryError } from './errors/CompletedTestInvalidCategoryError';
 import { IDateFormatter } from '../util/IDateFormatter';
 import { determineDl25TestType } from '../util/TestTypeLookup';
+import { convertDl25TestCategory } from '../util/TestCategoryConvertor';
 import { licenceToIssue } from '@dvsa/mes-microservice-common/application/utils/licence-type';
 import { get } from 'lodash';
-import { PassCompletion, CategoryCode } from '@dvsa/mes-test-schema/categories/common';
+import { PassCompletion } from '@dvsa/mes-test-schema/categories/common';
 
 @injectable()
 export class TARSPayloadConverter implements ITARSPayloadConverter {
@@ -72,7 +73,7 @@ export class TARSPayloadConverter implements ITARSPayloadConverter {
       checkDigit,
       language: communicationPreferences.conductedLanguage === 'English' ? 'E' : 'W',
       licenceSurrender: this.setLicenceSurrendertoFalseIfNotPresent(passCompletion),
-      dl25Category: this.dl25CategoryConversion(category),
+      dl25Category: convertDl25TestCategory(category),
       dl25TestType: testType,
       automaticTest: licenceToIssue(category, transmission, code78Present) === 'Automatic',
       extendedTest: testSlotAttributes.extendedTest,
@@ -88,14 +89,6 @@ export class TARSPayloadConverter implements ITARSPayloadConverter {
   private setLicenceSurrendertoFalseIfNotPresent(passCompletion: Partial<PassCompletion> | undefined): boolean {
     if (!passCompletion) return false;
     return get(passCompletion, 'provisionalLicenceProvided', false);
-  }
-
-  private dl25CategoryConversion(category: CategoryCode): string {
-    if (category.indexOf('EU') === 0) {
-      return category.substring(2);
-    }
-
-    return category;
   }
 
   private populatePassCertificateIfPresent(

--- a/src/functions/tarsUpload/domain/util/TestCategoryConvertor.ts
+++ b/src/functions/tarsUpload/domain/util/TestCategoryConvertor.ts
@@ -1,0 +1,9 @@
+import { CategoryCode } from '@dvsa/mes-test-schema/categories/common';
+
+export const convertDl25TestCategory = (category: CategoryCode): string => {
+  if (category.indexOf('EU') === 0) {
+    return category.substring(2);
+  }
+
+  return category;
+};

--- a/src/functions/tarsUpload/domain/util/TestTypeLookup.ts
+++ b/src/functions/tarsUpload/domain/util/TestTypeLookup.ts
@@ -13,10 +13,10 @@ export const determineDl25TestType = (category: string): number | undefined => {
        // Note that some extra data will be needed in MES to identify CPC tests, if MES adds support for them...
        // LGV (Lorry) CPC (all C Categories) => 44
        // PCV (Bus) CPC (all D Categories) => 44
-       ['EUA1M1', 16], ['EUA1M2', 1],
-       ['EUA2M1', 16], ['EUA2M2', 1],
-       ['EUAM1', 16], ['EUAM2', 1],
-       ['EUAMM1', 17], ['EUAMM2', 9],
+       ['A1M1', 16], ['A1M2', 1],
+       ['A2M1', 16], ['A2M2', 1],
+       ['AM1', 16], ['AM2', 1],
+       ['AMM1', 17], ['AMM2', 9],
   ]);
   const testType = mapping.get(category);
   return testType;

--- a/src/functions/tarsUpload/domain/util/TestTypeLookup.ts
+++ b/src/functions/tarsUpload/domain/util/TestTypeLookup.ts
@@ -13,10 +13,10 @@ export const determineDl25TestType = (category: string): number | undefined => {
        // Note that some extra data will be needed in MES to identify CPC tests, if MES adds support for them...
        // LGV (Lorry) CPC (all C Categories) => 44
        // PCV (Bus) CPC (all D Categories) => 44
-       ['A1M1', 16], ['A1M2', 1],
-       ['A2M1', 16], ['A2M2', 1],
-       ['AM1', 16], ['AM2', 1],
-       ['AMM1', 17], ['AMM2', 9],
+       ['EUA1M1', 16], ['EUA1M2', 1],
+       ['EUA2M1', 16], ['EUA2M2', 1],
+       ['EUAM1', 16], ['EUAM2', 1],
+       ['EUAMM1', 17], ['EUAMM2', 9],
   ]);
   const testType = mapping.get(category);
   return testType;

--- a/src/functions/tarsUpload/domain/util/__tests__/TestCategoryConvertor.spec.ts
+++ b/src/functions/tarsUpload/domain/util/__tests__/TestCategoryConvertor.spec.ts
@@ -1,0 +1,57 @@
+import { convertDl25TestCategory } from '../TestCategoryConvertor';
+import { CategoryCode } from '@dvsa/mes-test-schema/categories/common';
+
+describe('convertDl25TestCategory', () => {
+
+  describe('EU prefixed category codes', () => {
+    const catATestCases = [
+      { category: 'EUA1M1' as CategoryCode, expected: 'A1M1' },
+      { category: 'EUA1M2' as CategoryCode, expected: 'A1M2' },
+      { category: 'EUA2M1' as CategoryCode, expected: 'A2M1' },
+      { category: 'EUA2M2' as CategoryCode, expected: 'A2M2' },
+      { category: 'EUAM1' as CategoryCode, expected: 'AM1' },
+      { category: 'EUAM2' as CategoryCode, expected: 'AM2' },
+      { category: 'EUAMM1' as CategoryCode, expected: 'AMM1' },
+      { category: 'EUAMM2' as CategoryCode, expected: 'AMM2' },
+    ];
+
+    catATestCases.forEach((test) => {
+      it(`should return DL25 test category ${test.expected} for category ${test.category}`, () => {
+        expect(convertDl25TestCategory(test.category)).toBe(test.expected);
+      });
+    });
+
+  });
+
+  describe('non EU prefixed category codes', () => {
+    const nonCatATestCases = [
+      { category: 'A' as CategoryCode, expected: 'A' },
+      { category: 'A1' as CategoryCode, expected: 'A1' },
+      { category: 'A2' as CategoryCode, expected: 'A2' },
+      { category: 'ADI2' as CategoryCode, expected: 'ADI2' },
+      { category: 'ADI3' as CategoryCode, expected: 'ADI3' },
+      { category: 'AM' as CategoryCode, expected: 'AM' },
+      { category: 'B' as CategoryCode, expected: 'B' },
+      { category: 'B1' as CategoryCode, expected: 'B1' },
+      { category: 'B+E' as CategoryCode, expected: 'B+E' },
+      { category: 'C' as CategoryCode, expected: 'C' },
+      { category: 'C1' as CategoryCode, expected: 'C1' },
+      { category: 'C1+E' as CategoryCode, expected: 'C1+E' },
+      { category: 'CCPC' as CategoryCode, expected: 'CCPC' },
+      { category: 'C+E' as CategoryCode, expected: 'C+E' },
+      { category: 'D' as CategoryCode, expected: 'D' },
+      { category: 'D1' as CategoryCode, expected: 'D1' },
+      { category: 'D1+E' as CategoryCode, expected: 'D1+E' },
+      { category: 'DCPC' as CategoryCode, expected: 'DCPC' },
+      { category: 'D+E' as CategoryCode, expected: 'D+E' },
+    ];
+
+    nonCatATestCases.forEach((test) => {
+      it(`should return unmodified category code if category is ${test.category}`, () => {
+        expect(convertDl25TestCategory(test.category)).toBe(test.expected);
+      });
+    });
+
+  });
+
+});

--- a/src/functions/tarsUpload/domain/util/__tests__/TestTypeLookup.spec.ts
+++ b/src/functions/tarsUpload/domain/util/__tests__/TestTypeLookup.spec.ts
@@ -17,14 +17,14 @@ describe('determineDl25TestType', () => {
         { category: 'G', expected: 6 },
         { category: 'H', expected: 7 },
         { category: 'K', expected: 8 },
-        { category: 'A1M1', expected: 16 },
-        { category: 'A1M2', expected: 1 },
-        { category: 'A2M1', expected: 16 },
-        { category: 'A2M2', expected: 1 },
-        { category: 'AM1', expected: 16 },
-        { category: 'AM2', expected: 1 },
-        { category: 'AMM1', expected: 17 },
-        { category: 'AMM2', expected: 9 },
+        { category: 'EUA1M1', expected: 16 },
+        { category: 'EUA1M2', expected: 1 },
+        { category: 'EUA2M1', expected: 16 },
+        { category: 'EUA2M2', expected: 1 },
+        { category: 'EUAM1', expected: 16 },
+        { category: 'EUAM2', expected: 1 },
+        { category: 'EUAMM1', expected: 17 },
+        { category: 'EUAMM2', expected: 9 },
   ];
 
   validCategoryTestCases.forEach((test) => {

--- a/src/functions/tarsUpload/domain/util/__tests__/TestTypeLookup.spec.ts
+++ b/src/functions/tarsUpload/domain/util/__tests__/TestTypeLookup.spec.ts
@@ -17,14 +17,14 @@ describe('determineDl25TestType', () => {
         { category: 'G', expected: 6 },
         { category: 'H', expected: 7 },
         { category: 'K', expected: 8 },
-        { category: 'EUA1M1', expected: 16 },
-        { category: 'EUA1M2', expected: 1 },
-        { category: 'EUA2M1', expected: 16 },
-        { category: 'EUA2M2', expected: 1 },
-        { category: 'EUAM1', expected: 16 },
-        { category: 'EUAM2', expected: 1 },
-        { category: 'EUAMM1', expected: 17 },
-        { category: 'EUAMM2', expected: 9 },
+        { category: 'A1M1', expected: 16 },
+        { category: 'A1M2', expected: 1 },
+        { category: 'A2M1', expected: 16 },
+        { category: 'A2M2', expected: 1 },
+        { category: 'AM1', expected: 16 },
+        { category: 'AM2', expected: 1 },
+        { category: 'AMM1', expected: 17 },
+        { category: 'AMM2', expected: 9 },
   ];
 
   validCategoryTestCases.forEach((test) => {


### PR DESCRIPTION
# Description and relevant Jira numbers
- Handles the absence of a provisional licence surrender field not existing in a Mod 1 test
- Uses the utility type `Partial` to render the passCompletion keys to be optional
- Adds a `convertDl25TestCategory()` utility function to handle the conversion of A category codes to remove the 'EU' prefix which TARS rejects.
- Tested against TARS dev02 for a pass, fail and termination of a Mod 1 test.

## Pull Request checklist

- [ ] [WIP] tag removed from PR title
- [ ] PR has an understandable description

## Git feature branch checklist

- [ ] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [ ] branch rebased against the latest develop

## Sign off process checklist

- [ ] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [ ] Reviewers selected in Github
- [ ] PR link added to JIRA