### PR TITLE
MES-6084: Upgrade mes-test-schema version to 3.31.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -159,9 +159,9 @@
       }
     },
     "@dvsa/mes-test-schema": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.28.0.tgz",
-      "integrity": "sha512-BSuhxpj/LwwVdVtsDxEk5qrjReDfZYa5wpsGqu1wTiA5xOW8LjViHKXPJNzHptG3HqPFl+l1itcypLBzze+CWQ==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.31.0.tgz",
+      "integrity": "sha512-da8ggSPk2rlF0hmmM3TJr4udR+S317XjDU7R2dUi7sYGgv/Si/xk0vJAyEYhkejVqh6xxmJmHng7VnZyIIfXDA==",
       "dev": true
     },
     "@fimbul/bifrost": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {
-    "@dvsa/mes-test-schema": "3.28.0",
+    "@dvsa/mes-test-schema": "3.31.0",
     "@types/aws-lambda": "^8.10.13",
     "@types/aws-sdk": "^2.7.0",
     "@types/jasmine": "^2.8.9",


### PR DESCRIPTION
Upgrading to use the latest mes-test-schema